### PR TITLE
Bump commons-compress from 1.15 to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.15</version>
+            <version>1.21</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-compress from 1.15 to 1.21.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>